### PR TITLE
Mya prim testing

### DIFF
--- a/src/authoring/CMakeLists.txt
+++ b/src/authoring/CMakeLists.txt
@@ -106,6 +106,7 @@ catkin_install_python(PROGRAMS
     nodes/rviz_manager
     test/test_twist.py
     test/test_wipe.py
+    test/test_gripper.py
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(TARGETS pandaJacob

--- a/src/authoring/CMakeLists.txt
+++ b/src/authoring/CMakeLists.txt
@@ -107,6 +107,7 @@ catkin_install_python(PROGRAMS
     test/test_twist.py
     test/test_wipe.py
     test/test_gripper.py
+    test/test_move_force.py
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(TARGETS pandaJacob

--- a/src/authoring/nodes/mover_server
+++ b/src/authoring/nodes/mover_server
@@ -212,9 +212,10 @@ class AuthoringAction(object):
             #    self.camera_control(False)
 
             self._starting_pose = self.get_pose_from_trans(self._tfBuffer.lookup_transform("panda_link0", "panda_gripper", rospy.Time(0)))
-            
 
+            
             self.get_pose_rot(self._starting_pose.pose, goal.goal.pose.constraint_frame)
+
         else:
             t = rospy.Time.now()
             goal.goal.pose.header.frame_id = REFERENCE_FRAME
@@ -239,6 +240,7 @@ class AuthoringAction(object):
         #if goal.goal.type == goal.goal.MOVE_FORCE:
         #    goal.goal.pose.pose.position.z = self._starting_pose.pose.position.z
         goal.goal.pose.header.stamp = self._starting_time + rospy.Duration(self.get_time_between_pose(self._starting_pose.pose, goal.goal.pose.pose))
+
         self._current_action = goal.goal
 
         r = rospy.Rate(self._freq)
@@ -456,10 +458,11 @@ class AuthoringAction(object):
         linear[2] = 0
         force_threshold = self._push_force*.7
         progress = min((rospy.Time.now() - self._starting_time).to_sec()/(action.pose.header.stamp - self._starting_time).to_sec(),1)
-        
+
         if np.all(np.abs(linear)<linear_threshold) and np.all(np.abs(angular)<angular_threshold) and self._biased_wrench.force.z < force_threshold:
             return True
-        goal.pose = self.interpolate_poses(self._starting_pose.pose, action.pose.pose,progress)
+        
+        goal.pose = self.interpolate_poses(self._starting_pose.pose, action.pose.pose, progress)
         goal.wrench.force.z = self._push_force
         
         self.publish_pose(goal)

--- a/src/authoring/nodes/mover_server
+++ b/src/authoring/nodes/mover_server
@@ -445,8 +445,9 @@ class AuthoringAction(object):
         
         linear_threshold = .001
         angular_threshold = .01
-        if np.all(np.abs(linear[:1])<linear_threshold) and linear[2]>0 and np.all(np.abs(angular)<angular_threshold):
-
+        if np.all(np.abs(linear[:2])<linear_threshold) and linear[2]>0 and np.all(np.abs(angular)<angular_threshold):
+            print(np.abs(linear[:2]), linear[2])
+            print(np.abs(angular))
             self._reached_position = True
             return True
         if (action.sim.data or self._virtual) and linear[2]>-.005:

--- a/src/authoring/nodes/planner
+++ b/src/authoring/nodes/planner
@@ -738,8 +738,13 @@ class Planner(object):
             goal.goal = action
             self._client.send_goal(goal)
             print(self._client.wait_for_result())
-            result = self._client.get_result().success.data
-            if not result:
+
+            result_data = self._client.get_result()
+            print("RESULT:", result_data)
+            if result_data:
+                result = result_data.success.data
+            if not result_data or not result:
+                print("FAILED PLAN")
                 self._event_pub.publish("display_message;Failed Plan")
                 self._plan = []
                 goal = authoring_msgs.msg.AuthoringGoal()

--- a/src/authoring/nodes/planner
+++ b/src/authoring/nodes/planner
@@ -721,13 +721,13 @@ class Planner(object):
         return h
 
     def run_plan(self,starting):
-        print("running plan")
+        # print("running plan")
         result = False
 
         for action in self._plan[starting:]:
             if(self.get_type(action) == ""):
                 print("unknown action" + str(action))
-            print("At action "+self.get_type(action))
+            # print("At action "+self.get_type(action))
             if action.finished.data:
                 event = "action_finished;"+self.get_type(action)
                 if self.get_type(action) != "Reset":
@@ -737,10 +737,11 @@ class Planner(object):
             goal = authoring_msgs.msg.AuthoringGoal()
             goal.goal = action
             self._client.send_goal(goal)
-            print(self._client.wait_for_result())
+            self._client.wait_for_result()
+            # print(self._client.wait_for_result())
 
             result_data = self._client.get_result()
-            print("RESULT:", result_data)
+            # print("RESULT:", result_data)
             if result_data:
                 result = result_data.success.data
             if not result_data or not result:

--- a/src/authoring/test/test_gripper.py
+++ b/src/authoring/test/test_gripper.py
@@ -1,6 +1,9 @@
 """
 Tests gripper commands GRASP and RELEASE. Gripper should open and 
-then close 3 seconds after.
+then close 3 seconds after. 
+
+Note: The gripper needs to be given something to grasp. If it 
+doesn't have something, it will go to the reset position and not open.
 """
 
 
@@ -20,7 +23,6 @@ def test_gripper():
     for i in range(2):
 
         action = Action(type=8,  # GRASP
-                        item=String(data="BOLT") # NOT SURE IF THIS IS CORRECT
                         )
 
         cmd = Command()
@@ -41,7 +43,6 @@ def test_gripper():
     for i in range(2):
 
         action = Action(type=9,  # RELEASE
-                        item=String(data="BOLT") # NOT SURE IF THIS IS CORRECT
                         )
 
         cmd = Command()
@@ -55,7 +56,7 @@ def test_gripper():
 
 
 if __name__ == '__main__':
-    rospy.init_node('test_twist', anonymous=True)
+    rospy.init_node('teset_gripper', anonymous=True)
     
     test_gripper()
  

--- a/src/authoring/test/test_gripper.py
+++ b/src/authoring/test/test_gripper.py
@@ -1,0 +1,61 @@
+"""
+Tests gripper commands GRASP and RELEASE. Gripper should open and 
+then close 3 seconds after.
+"""
+
+
+import rospy
+from std_msgs.msg import String
+from authoring_msgs.msg import Command, Action 
+from panda_ros_msgs.msg import HybridPose, HybridPoseArray
+
+
+def test_gripper():
+    pub = rospy.Publisher('/parser/command', Command, queue_size=1)
+    rate = rospy.Rate(10) # 10hz
+
+    # FIRST GRASP
+    # For some reason, a single message does not go through so need to
+    # send at least 2.
+    for i in range(2):
+
+        action = Action(type=8,  # GRASP
+                        item=String(data="BOLT") # NOT SURE IF THIS IS CORRECT
+                        )
+
+        cmd = Command()
+        cmd.type = 2  # EXEC
+        cmd.core_action = [action]
+
+        rospy.loginfo(cmd)
+        pub.publish(cmd)
+        rate.sleep()
+
+    # Wait for 3 seconds
+    pause = rospy.Rate(1/3)
+    pause.sleep()
+
+    # THEN RELEASE
+    # For some reason, a single message does not go through so need to
+    # send at least 2.
+    for i in range(2):
+
+        action = Action(type=9,  # RELEASE
+                        item=String(data="BOLT") # NOT SURE IF THIS IS CORRECT
+                        )
+
+        cmd = Command()
+        cmd.type = 2  # EXEC
+        cmd.core_action = [action]
+
+        rospy.loginfo(cmd)
+        pub.publish(cmd)
+        rate.sleep()
+
+
+
+if __name__ == '__main__':
+    rospy.init_node('test_twist', anonymous=True)
+    
+    test_gripper()
+ 

--- a/src/authoring/test/test_gripper.py
+++ b/src/authoring/test/test_gripper.py
@@ -14,44 +14,36 @@ from panda_ros_msgs.msg import HybridPose, HybridPoseArray
 
 
 def test_gripper():
-    pub = rospy.Publisher('/parser/command', Command, queue_size=1)
+    pub = rospy.Publisher('/parser/command', Command, queue_size=1, latch=True)
     rate = rospy.Rate(10) # 10hz
 
     # FIRST GRASP
-    # For some reason, a single message does not go through so need to
-    # send at least 2.
-    for i in range(2):
+    action = Action(type=8,  # GRASP
+                    )
 
-        action = Action(type=8,  # GRASP
-                        )
+    cmd = Command()
+    cmd.type = 2  # EXEC
+    cmd.core_action = [action]
 
-        cmd = Command()
-        cmd.type = 2  # EXEC
-        cmd.core_action = [action]
-
-        rospy.loginfo(cmd)
-        pub.publish(cmd)
-        rate.sleep()
+    rospy.loginfo(cmd)
+    pub.publish(cmd)
+    rate.sleep()
 
     # Wait for 3 seconds
     pause = rospy.Rate(1/3)
     pause.sleep()
 
     # THEN RELEASE
-    # For some reason, a single message does not go through so need to
-    # send at least 2.
-    for i in range(2):
+    action = Action(type=9,  # RELEASE
+                    )
 
-        action = Action(type=9,  # RELEASE
-                        )
+    cmd = Command()
+    cmd.type = 2  # EXEC
+    cmd.core_action = [action]
 
-        cmd = Command()
-        cmd.type = 2  # EXEC
-        cmd.core_action = [action]
-
-        rospy.loginfo(cmd)
-        pub.publish(cmd)
-        rate.sleep()
+    rospy.loginfo(cmd)
+    pub.publish(cmd)
+    rate.sleep()
 
 
 

--- a/src/authoring/test/test_gripper.py
+++ b/src/authoring/test/test_gripper.py
@@ -3,7 +3,7 @@ Tests gripper commands GRASP and RELEASE. Gripper should open and
 then close 3 seconds after. 
 
 Note: The gripper needs to be given something to grasp. If it 
-doesn't have something, it will go to the reset position and not open.
+doesn't have something, it will go to the reset position.
 """
 
 

--- a/src/authoring/test/test_move_force.py
+++ b/src/authoring/test/test_move_force.py
@@ -65,7 +65,7 @@ def test_move_force():
     hybrid_pose = HybridPose()
     hybrid_pose.pose.position.x=0.5 # Forward
     hybrid_pose.pose.position.y=0.2  # Sideways
-    # hybrid_pose.pose.position.z=0.1 # Up
+    hybrid_pose.pose.position.z=-0.23 # Up
     # hybrid_pose.sel_vector = [1,1,0,0,0,0]
     
     # This is facing Downward (x=0, y=0, z=0, w=1)

--- a/src/authoring/test/test_move_force.py
+++ b/src/authoring/test/test_move_force.py
@@ -34,7 +34,7 @@ def test_move_force():
         hybrid_pose.constraint_frame.w = 1 
 
         header = Header()
-        header.stamp = rospy.Time.now() + rospy.Duration(0.05)  # 0.5 seconds into the future  # Current time
+        header.stamp = rospy.Time.now() + rospy.Duration()  # 0.5 seconds into the future  # Current time
         hybrid_pose.header = header
 
         action = Action(type=6,  # MOVE
@@ -71,10 +71,14 @@ def test_move_force():
     # This is facing Downward (x=0, y=0, z=0, w=1)
     hybrid_pose.pose.orientation.w=1
 
+    # The mover does something where it transforms based on the constraint frame (quaternion)
+    # To have no transform, the following should be set: x=0, y=0, z=0, w=1
+    hybrid_pose.constraint_frame.w = 1 
+
 
     # Timestamp required
     header = Header()
-    header.stamp = rospy.Time.now() + rospy.Duration(0.5)  # 0.5 seconds into the future  # Current time
+    header.stamp = rospy.Time.now() + rospy.Duration(3)  # 0.5 seconds into the future  # Current time
     hybrid_pose.header = header
     
 

--- a/src/authoring/test/test_move_force.py
+++ b/src/authoring/test/test_move_force.py
@@ -1,11 +1,11 @@
 """
 Tests MOVE_FORCE primitive. How this works is that the robot
-will move to the x, y position provided (z not allowed) while
-maintaining a constant force (measured when the command triggered).
-If force drops too much, the robot will stop.
+will move to the (x, y)=(0.5, 0.3) position provided (z not allowed) while
+maintaining force of ~7 newtons downwards. This means that the 
+robot will continue moving slowly downwards once it reaches the x,y position
+until an upward force of >7 Newtons is applied by the user (this can be a gentle upward push).
 
 """
-
 
 
 import rospy
@@ -15,70 +15,26 @@ from panda_ros_msgs.msg import HybridPose, HybridPoseArray
 
 
 def test_move_force():
-    pub = rospy.Publisher('/parser/command', Command, queue_size=1)
+    pub = rospy.Publisher('/parser/command', Command, queue_size=1, latch=True)
     rate = rospy.Rate(10) # 10hz
 
-    # First move to position
-    for i in range(2):
-        hybrid_pose = HybridPose()
-        hybrid_pose.sel_vector = [1,1,1,0,0,0]
-        hybrid_pose.pose.position.x=0.5 # Forward
-        hybrid_pose.pose.position.y=0.1  # Sideways
-        hybrid_pose.pose.position.z=-0.22 # Up
-        
-        # This is facing Downward (x=0, y=0, z=0, w=1)
-        hybrid_pose.pose.orientation.w=1
 
-        # The mover does something where it transforms based on the constraint frame (quaternion)
-        # To have no transform, the following should be set: x=0, y=0, z=0, w=1
-        hybrid_pose.constraint_frame.w = 1 
-
-        header = Header()
-        header.stamp = rospy.Time.now() + rospy.Duration()  # 0.5 seconds into the future  # Current time
-        hybrid_pose.header = header
-
-        action = Action(type=6,  # MOVE
-                        pose=hybrid_pose, 
-                        item=String(data="NONE")
-                        )
-
-
-        
-        cmd = Command()
-        cmd.type = 2  # EXEC
-        cmd.core_action = [action]
-
-
-        rospy.loginfo(cmd)
-        pub.publish(cmd)
-        rate.sleep()
-
-  
-    pause = rospy.Rate(1/5) 
-    pause.sleep() # Wait 5 seconds
-
-    # Then test move with force by moving slightly right
-
-
-    # Z position, selection vector, and constraint frame
+    # Z position and selection vector
     # do not matter bc set in mover_server
     hybrid_pose = HybridPose()
     hybrid_pose.pose.position.x=0.5 # Forward
-    hybrid_pose.pose.position.y=0.2  # Sideways
-    hybrid_pose.pose.position.z=-0.23 # Up
-    # hybrid_pose.sel_vector = [1,1,0,0,0,0]
-    
-    # This is facing Downward (x=0, y=0, z=0, w=1)
-    hybrid_pose.pose.orientation.w=1
+    hybrid_pose.pose.position.y=0.3  # Sideways
 
-    # The mover does something where it transforms based on the constraint frame (quaternion)
-    # To have no transform, the following should be set: x=0, y=0, z=0, w=1
+    hybrid_pose.pose.orientation.w=1 # This is facing Downward (x=0, y=0, z=0, w=1)
+
+    # We still need a constraint frame bc although it is set in move_force in mover_server,
+    # mover_server also uses it to set _starting_pose
     hybrid_pose.constraint_frame.w = 1 
 
 
     # Timestamp required
     header = Header()
-    header.stamp = rospy.Time.now() + rospy.Duration(3)  # 0.5 seconds into the future  # Current time
+    header.stamp = rospy.Time.now()
     hybrid_pose.header = header
     
 

--- a/src/authoring/test/test_move_force.py
+++ b/src/authoring/test/test_move_force.py
@@ -1,0 +1,100 @@
+"""
+Tests MOVE_FORCE primitive. How this works is that the robot
+will move to the x, y position provided (z not allowed) while
+maintaining a constant force (measured when the command triggered).
+If force drops too much, the robot will stop.
+
+"""
+
+
+
+import rospy
+from std_msgs.msg import String, Header
+from authoring_msgs.msg import Command, Action 
+from panda_ros_msgs.msg import HybridPose, HybridPoseArray
+
+
+def test_move_force():
+    pub = rospy.Publisher('/parser/command', Command, queue_size=1)
+    rate = rospy.Rate(10) # 10hz
+
+
+    for i in range(2):
+        hybrid_pose = HybridPose()
+        hybrid_pose.sel_vector = [1,1,1,0,0,0]
+        hybrid_pose.pose.position.x=0.5 # Forward
+        hybrid_pose.pose.position.y=0.0  # Sideways
+        hybrid_pose.pose.position.z=-0.1 # Up
+        
+        # This is facing Downward (x=0, y=0, z=0, w=1)
+        hybrid_pose.pose.orientation.w=1
+
+        # The mover does something where it transforms based on the constraint frame (quaternion)
+        # To have no transform, the following should be set: x=0, y=0, z=0, w=1
+        hybrid_pose.constraint_frame.w = 1 
+        
+
+
+        action = Action(type=6,  # MOVE
+                        pose=hybrid_pose, 
+                        item=String(data="NONE")
+                        )
+
+
+        
+        cmd = Command()
+        cmd.type = 2  # EXEC
+        cmd.core_action = [action]
+
+
+        rospy.loginfo(cmd)
+        pub.publish(cmd)
+        rate.sleep()
+
+    pause = rospy.Rate(1/10) 
+    pause.sleep() # Wait 10 seconds
+
+    # Then test move with force by moving slightly right
+    # For some reason, a single message does not go through so need to
+    # send at least 2.
+    for i in range(2):
+
+        # Z position, selection vector, and constraint frame
+        # do not matter bc set in mover_server
+        hybrid_pose = HybridPose()
+        hybrid_pose.pose.position.x=0.5 # Forward
+        hybrid_pose.pose.position.y=0.01  # Sideways
+        
+        # This is facing Downward (x=0, y=0, z=0, w=1)
+        hybrid_pose.pose.orientation.w=1
+
+
+        # Timestamp required
+        header = Header()
+        header.stamp = rospy.Time.now()  # Current time
+        hybrid_pose.header = header
+        
+ 
+
+        action = Action(type=16,  # MOVE_FORCE
+                        pose=hybrid_pose, 
+                        item=String(data="NONE")
+                        )
+
+
+        
+        cmd = Command()
+        cmd.type = 2  # EXEC
+        cmd.core_action = [action]
+
+
+        rospy.loginfo(cmd)
+        pub.publish(cmd)
+        rate.sleep()
+
+
+if __name__ == '__main__':
+    rospy.init_node('test_move_force', anonymous=True)
+    
+    test_move_force()
+ 

--- a/src/authoring/test/test_move_force.py
+++ b/src/authoring/test/test_move_force.py
@@ -18,13 +18,13 @@ def test_move_force():
     pub = rospy.Publisher('/parser/command', Command, queue_size=1)
     rate = rospy.Rate(10) # 10hz
 
-
+    # First move to position
     for i in range(2):
         hybrid_pose = HybridPose()
         hybrid_pose.sel_vector = [1,1,1,0,0,0]
         hybrid_pose.pose.position.x=0.5 # Forward
-        hybrid_pose.pose.position.y=0.0  # Sideways
-        hybrid_pose.pose.position.z=-0.1 # Up
+        hybrid_pose.pose.position.y=0.1  # Sideways
+        hybrid_pose.pose.position.z=-0.22 # Up
         
         # This is facing Downward (x=0, y=0, z=0, w=1)
         hybrid_pose.pose.orientation.w=1
@@ -32,8 +32,10 @@ def test_move_force():
         # The mover does something where it transforms based on the constraint frame (quaternion)
         # To have no transform, the following should be set: x=0, y=0, z=0, w=1
         hybrid_pose.constraint_frame.w = 1 
-        
 
+        header = Header()
+        header.stamp = rospy.Time.now() + rospy.Duration(0.05)  # 0.5 seconds into the future  # Current time
+        hybrid_pose.header = header
 
         action = Action(type=6,  # MOVE
                         pose=hybrid_pose, 
@@ -51,46 +53,47 @@ def test_move_force():
         pub.publish(cmd)
         rate.sleep()
 
-    pause = rospy.Rate(1/10) 
-    pause.sleep() # Wait 10 seconds
+  
+    pause = rospy.Rate(1/5) 
+    pause.sleep() # Wait 5 seconds
 
     # Then test move with force by moving slightly right
-    # For some reason, a single message does not go through so need to
-    # send at least 2.
-    for i in range(2):
-
-        # Z position, selection vector, and constraint frame
-        # do not matter bc set in mover_server
-        hybrid_pose = HybridPose()
-        hybrid_pose.pose.position.x=0.5 # Forward
-        hybrid_pose.pose.position.y=0.01  # Sideways
-        
-        # This is facing Downward (x=0, y=0, z=0, w=1)
-        hybrid_pose.pose.orientation.w=1
 
 
-        # Timestamp required
-        header = Header()
-        header.stamp = rospy.Time.now()  # Current time
-        hybrid_pose.header = header
-        
- 
-
-        action = Action(type=16,  # MOVE_FORCE
-                        pose=hybrid_pose, 
-                        item=String(data="NONE")
-                        )
-
-
-        
-        cmd = Command()
-        cmd.type = 2  # EXEC
-        cmd.core_action = [action]
+    # Z position, selection vector, and constraint frame
+    # do not matter bc set in mover_server
+    hybrid_pose = HybridPose()
+    hybrid_pose.pose.position.x=0.5 # Forward
+    hybrid_pose.pose.position.y=0.2  # Sideways
+    # hybrid_pose.pose.position.z=0.1 # Up
+    # hybrid_pose.sel_vector = [1,1,0,0,0,0]
+    
+    # This is facing Downward (x=0, y=0, z=0, w=1)
+    hybrid_pose.pose.orientation.w=1
 
 
-        rospy.loginfo(cmd)
-        pub.publish(cmd)
-        rate.sleep()
+    # Timestamp required
+    header = Header()
+    header.stamp = rospy.Time.now() + rospy.Duration(0.5)  # 0.5 seconds into the future  # Current time
+    hybrid_pose.header = header
+    
+
+
+    action = Action(type=16,  # MOVE_FORCE
+                    pose=hybrid_pose, 
+                    item=String(data="NONE")
+                    )
+
+
+    
+    cmd = Command()
+    cmd.type = 2  # EXEC
+    cmd.core_action = [action]
+
+
+    rospy.loginfo(cmd)
+    pub.publish(cmd)
+    rate.sleep()
 
 
 if __name__ == '__main__':

--- a/src/authoring/test/test_twist.py
+++ b/src/authoring/test/test_twist.py
@@ -1,5 +1,5 @@
 """
-Tests untwisting a large bolt ~1 rotation with the UNTWIST command.
+Tests untwisting a large bolt ~1 rotation with the UNSCREW command.
 Bolt need to be placed at (x,y,z) = (0.52, 0, -0.24). You can eyeball
 this as the place where the gripper first goes down before closing.
 

--- a/src/authoring/test/test_twist.py
+++ b/src/authoring/test/test_twist.py
@@ -16,45 +16,42 @@ from panda_ros_msgs.msg import HybridPose, HybridPoseArray
 
 
 def test_twist():
-    pub = rospy.Publisher('/parser/command', Command, queue_size=1)
+    pub = rospy.Publisher('/parser/command', Command, queue_size=1, latch=True)
     rate = rospy.Rate(10) # 10hz
 
-    # For some reason, a single message does not go through so need to
-    # send at least 2.
-    for i in range(2):
 
-        hybrid_pose = HybridPose()
-        hybrid_pose.sel_vector = [1,1,1,0,0,0]
-        hybrid_pose.pose.position.x=0.52 # Forward
-        hybrid_pose.pose.position.y=0.0  # Sideways
-        hybrid_pose.pose.position.z=-0.24 # Up
-        
-        # This is facing Downward (x=0, y=0, z=0, w=1)
-        hybrid_pose.pose.orientation.w=1
+    hybrid_pose = HybridPose()
+    hybrid_pose.sel_vector = [1,1,1,0,0,0]
+    hybrid_pose.pose.position.x=0.52 # Forward
+    hybrid_pose.pose.position.y=0.0  # Sideways
+    hybrid_pose.pose.position.z=-0.24 # Up
+    
+    # This is facing Downward (x=0, y=0, z=0, w=1)
+    hybrid_pose.pose.orientation.w=1
 
-        # The mover does something where it transforms based on the constraint frame (quaternion)
-        # To have no transform, the following should be set: x=0, y=0, z=0, w=1
-        hybrid_pose.constraint_frame.w = 1 
+    # The mover does something where it transforms based on the constraint frame (quaternion)
+    # To have no transform, the following should be set: x=0, y=0, z=0, w=1
+    hybrid_pose.constraint_frame.w = 1 
 
 
-        poses = HybridPoseArray()
-        poses.poses = [hybrid_pose] 
+    poses = HybridPoseArray()
+    poses.poses = [hybrid_pose] 
 
-        action = Action(type=17,  # UNSCREW
-                        poses=poses, 
-                        item=String(data="BOLT") # NOT SURE IF THIS IS CORRECT
-                        )
-
-
-        
-        cmd = Command()
-        cmd.type = 2  # EXEC
-        cmd.core_action = [action]
+    action = Action(type=17,  # UNSCREW
+                    poses=poses, 
+                    item=String(data="BOLT") # NOT SURE IF THIS IS CORRECT
+                    )
 
 
-        rospy.loginfo(cmd)
-        pub.publish(cmd)
-        rate.sleep()
+    
+    cmd = Command()
+    cmd.type = 2  # EXEC
+    cmd.core_action = [action]
+
+
+    rospy.loginfo(cmd)
+    pub.publish(cmd)
+    rate.sleep()
 
 
 if __name__ == '__main__':

--- a/src/authoring/test/test_twist.py
+++ b/src/authoring/test/test_twist.py
@@ -1,3 +1,12 @@
+"""
+Tests untwisting a large bolt ~1 rotation with the UNTWIST command.
+Bolt need to be placed at (x,y,z) = (0.52, 0, -0.24). You can eyeball
+this as the place where the gripper first goes down before closing.
+
+Note: If the gripper does not grasp the bolt, it will "reset" without
+doing any twisting.
+"""
+
 import copy
 
 import rospy

--- a/src/authoring/test/test_wipe.py
+++ b/src/authoring/test/test_wipe.py
@@ -10,61 +10,58 @@ from panda_ros_msgs.msg import HybridPose, HybridPoseArray
 
 
 def test_wipe():
-    pub = rospy.Publisher('/parser/command', Command, queue_size=1)
+    pub = rospy.Publisher('/parser/command', Command, queue_size=1, latch=True)
     rate = rospy.Rate(10) # 10hz
 
-    # For some reason, a single message does not go through so need to
-    # send at least 2.
-    for i in range(2):
 
-        p0 = HybridPose()
-        p0.sel_vector = [1,1,1,0,0,0]
-        p0.pose.position.x=0.5 # Forward
-        p0.pose.position.y=0.0  # Sideways
-        p0.pose.position.z=-0.25 # Up
-        
-        # This is facing Downward (x=0, y=0, z=0, w=1)
-        p0.pose.orientation.w=1
+    p0 = HybridPose()
+    p0.sel_vector = [1,1,1,0,0,0]
+    p0.pose.position.x=0.5 # Forward
+    p0.pose.position.y=0.0  # Sideways
+    p0.pose.position.z=-0.25 # Up
+    
+    # This is facing Downward (x=0, y=0, z=0, w=1)
+    p0.pose.orientation.w=1
 
-        # The mover does something where it transforms based on the constraint frame (quaternion)
-        # To have no transform, the following should be set: x=0, y=0, z=0, w=1
-        p0.constraint_frame.w = 1 
+    # The mover does something where it transforms based on the constraint frame (quaternion)
+    # To have no transform, the following should be set: x=0, y=0, z=0, w=1
+    p0.constraint_frame.w = 1 
 
-        # P0 is where the robot picks up the eraser and the rest of the Ps
-        # make up the wipeable area which I'm making a Rectangle so P1 is upper left 
-        # (starting at same place as eraser), P2 is upper right, P3 is lower right, P4 is lower left
-        p1 = copy.deepcopy(p0)
-        p1.pose.position.x=0.6
-        p1.pose.position.z=-0.26
-        p2 = copy.deepcopy(p1)
-        p2.pose.position.y=0.1 # Move right abit
-        p3 = copy.deepcopy(p2)
-        p3.pose.position.x=0.5
-        p4 = copy.deepcopy(p1)
-        p4.pose.position.x=0.5
+    # P0 is where the robot picks up the eraser and the rest of the Ps
+    # make up the wipeable area which I'm making a Rectangle so P1 is upper left 
+    # (starting at same place as eraser), P2 is upper right, P3 is lower right, P4 is lower left
+    p1 = copy.deepcopy(p0)
+    p1.pose.position.x=0.6
+    p1.pose.position.z=-0.26
+    p2 = copy.deepcopy(p1)
+    p2.pose.position.y=0.1 # Move right abit
+    p3 = copy.deepcopy(p2)
+    p3.pose.position.x=0.5
+    p4 = copy.deepcopy(p1)
+    p4.pose.position.x=0.5
 
-        
+    
 
-        poses = HybridPoseArray()
+    poses = HybridPoseArray()
 
-        poses.poses = [p0, # Location of wiping object
-                        p1, p2, p3, p4] # Wipable area 
+    poses.poses = [p0, # Location of wiping object
+                    p1, p2, p3, p4] # Wipable area 
 
-        action = Action(type=3,  # WIPE
-                        poses=poses, 
-                        item=String(data="WHITEBOARD_ERASER") # NOT SURE IF THIS IS CORRECT
-                        )
+    action = Action(type=3,  # WIPE
+                    poses=poses, 
+                    item=String(data="WHITEBOARD_ERASER") # NOT SURE IF THIS IS CORRECT
+                    )
 
 
-        
-        cmd = Command()
-        cmd.type = 2  # EXEC
-        cmd.core_action = [action]
+    
+    cmd = Command()
+    cmd.type = 2  # EXEC
+    cmd.core_action = [action]
 
 
-        rospy.loginfo(cmd)
-        pub.publish(cmd)
-        rate.sleep()
+    rospy.loginfo(cmd)
+    pub.publish(cmd)
+    rate.sleep()
 
 if __name__ == '__main__':
     rospy.init_node('test_wipe', anonymous=True)

--- a/src/authoring/test/test_wipe.py
+++ b/src/authoring/test/test_wipe.py
@@ -32,11 +32,14 @@ def test_wipe():
     # (starting at same place as eraser), P2 is upper right, P3 is lower right, P4 is lower left
     p1 = copy.deepcopy(p0)
     p1.pose.position.x=0.6
-    p1.pose.position.z=-0.26
+
+
     p2 = copy.deepcopy(p1)
-    p2.pose.position.y=0.1 # Move right abit
+    p2.pose.position.y=0.1 # Move right a bit
+
     p3 = copy.deepcopy(p2)
     p3.pose.position.x=0.5
+    
     p4 = copy.deepcopy(p1)
     p4.pose.position.x=0.5
 


### PR DESCRIPTION
* Successfully tested GRASP, RELEASE, and MOVE_FORCE.
* Solved the MOVE_FORCE bug that caused the robot to jerk and error out:
  * The simple explanation is the that the MOVE_FORCE message needs the w in it's constraint frame set to 1 ( `hybrid_pose.constraint_frame.w = 1`). 
 
  * The longer explanation as to what caused everything is as follows. I originally did not think that the MOVE_FORCE message needed a constraint frame because the logic in mover_server (move_force() )  that handles the message, sets the constraint frame itself. However, this function uses self._starting_pose.pose to interpolate between the initial position and the final position and _starting_pose is set before move_force() is ever called. Right when _starting_pose is set, it goes through a constraint transform which uses the original MOVE_FORCE action message's constraint frame to transform the _starting_pose. Since I was not providing a constraint frame, the transformation sets _starting_pose to 0,0,0. So when move_force() roles around, it is sending the first interpolated point as ~(0,0,0) to the hybrid controller. The hybrid controller then freaks out because it can only handle small distances and (0,0,0) is very far from the robot's current position (around (0.5,0.2,-0.2 in my case)) . Such a large distance causes the hybrid controller to output a really large velocity which is passed the joint limits and causes the jerk and the error message we saw. So, setting  the w in the constraint frame  to 1 in the original MOVE_FORCE message means that _starting_pose is not transformed, so move_force() interpolates correctly, and the hybrid controller only receives close distances, which it is very happy with.